### PR TITLE
Add zoom animation to Julia visualizer

### DIFF
--- a/julia_visualizer.py
+++ b/julia_visualizer.py
@@ -1,12 +1,13 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider
+from matplotlib.animation import FuncAnimation
 
 
-def compute_julia(width, height, c, max_iter=300):
-    # Create complex plane
-    x = np.linspace(-1.5, 1.5, width)
-    y = np.linspace(-1.5, 1.5, height)
+def compute_julia(width, height, c, max_iter=300, xlim=(-1.5, 1.5), ylim=(-1.5, 1.5)):
+    """Compute the Julia set for a region of the complex plane."""
+    x = np.linspace(xlim[0], xlim[1], width)
+    y = np.linspace(ylim[0], ylim[1], height)
     X, Y = np.meshgrid(x, y)
     Z = X + 1j * Y
     C = np.full(Z.shape, c)
@@ -31,12 +32,14 @@ def compute_julia(width, height, c, max_iter=300):
 def main():
     width, height = 600, 600
     c = complex(-0.4, 0.6)
+    xlim = [-1.5, 1.5]
+    ylim = [-1.5, 1.5]
 
     fig, ax = plt.subplots()
     plt.subplots_adjust(bottom=0.25)
 
-    fractal = compute_julia(width, height, c)
-    im = ax.imshow(fractal, cmap='magma', origin='lower', extent=[-1.5, 1.5, -1.5, 1.5])
+    fractal = compute_julia(width, height, c, xlim=xlim, ylim=ylim)
+    im = ax.imshow(fractal, cmap='magma', origin='lower', extent=[xlim[0], xlim[1], ylim[0], ylim[1]])
     ax.set_xlabel('Re(z)')
     ax.set_ylabel('Im(z)')
     fig.suptitle(f'c = {c.real:.3f} + {c.imag:.3f}i')
@@ -50,13 +53,32 @@ def main():
 
     def update(val):
         c_new = complex(c_real_slider.val, c_imag_slider.val)
-        data = compute_julia(width, height, c_new)
+        data = compute_julia(width, height, c_new, xlim=tuple(xlim), ylim=tuple(ylim))
         im.set_data(data)
+        im.set_extent([xlim[0], xlim[1], ylim[0], ylim[1]])
         fig.suptitle(f'c = {c_new.real:.3f} + {c_new.imag:.3f}i')
         fig.canvas.draw_idle()
 
     c_real_slider.on_changed(update)
     c_imag_slider.on_changed(update)
+
+    def zoom(frame):
+        range_x = (xlim[1] - xlim[0]) * 0.97
+        range_y = (ylim[1] - ylim[0]) * 0.97
+        center_x = (xlim[0] + xlim[1]) / 2
+        center_y = (ylim[0] + ylim[1]) / 2
+        xlim[0] = center_x - range_x / 2
+        xlim[1] = center_x + range_x / 2
+        ylim[0] = center_y - range_y / 2
+        ylim[1] = center_y + range_y / 2
+
+        c_current = complex(c_real_slider.val, c_imag_slider.val)
+        data = compute_julia(width, height, c_current, xlim=tuple(xlim), ylim=tuple(ylim))
+        im.set_data(data)
+        im.set_extent([xlim[0], xlim[1], ylim[0], ylim[1]])
+        return [im]
+
+    FuncAnimation(fig, zoom, frames=200, interval=50, blit=False)
 
     plt.show()
 


### PR DESCRIPTION
## Summary
- extend `compute_julia` with adjustable plane limits
- integrate zoom animation with `FuncAnimation`
- update slider callback to account for zoomed view

## Testing
- `python -m py_compile julia_visualizer.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f405e5d14833099a5bbde11a5d89f