### PR TITLE
Add WebGL-based Julia set viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Julia Set WebGL Viewer</title>
+<style>
+  body { margin:0; display:flex; justify-content:center; align-items:center; height:100vh; background:#000; }
+  canvas { width:600px; height:600px; }
+  #controls { position:fixed; bottom:10px; left:50%; transform:translateX(-50%); color:#fff; }
+</style>
+</head>
+<body>
+<canvas id="glcanvas" width="600" height="600"></canvas>
+<div id="controls">
+  c = <span id="cval">-0.4 + 0.6i</span>
+</div>
+<script>
+const canvas = document.getElementById('glcanvas');
+const gl = canvas.getContext('webgl');
+
+function compileShader(type, source){
+  const s = gl.createShader(type);
+  gl.shaderSource(s, source);
+  gl.compileShader(s);
+  if(!gl.getShaderParameter(s, gl.COMPILE_STATUS)){
+    console.error(gl.getShaderInfoLog(s));
+  }
+  return s;
+}
+
+const vertSrc = `
+attribute vec2 a_position;
+void main(){
+  gl_Position = vec4(a_position, 0.0, 1.0);
+}`;
+
+const fragSrc = `
+precision highp float;
+uniform vec2 u_c;
+uniform float u_zoom;
+uniform vec2 u_center;
+uniform vec2 u_resolution;
+const int MAX_ITER = 300;
+void main(){
+  vec2 coord = (gl_FragCoord.xy / u_resolution - 0.5) * u_zoom + u_center;
+  vec2 z = coord;
+  int i;
+  for(i=0;i<MAX_ITER;i++){
+    vec2 z2 = vec2(z.x*z.x - z.y*z.y, 2.0*z.x*z.y) + u_c;
+    if(dot(z2,z2) > 4.0) break;
+    z = z2;
+  }
+  float t = float(i) / float(MAX_ITER);
+  gl_FragColor = vec4(vec3(t), 1.0);
+}`;
+
+const program = gl.createProgram();
+const vShader = compileShader(gl.VERTEX_SHADER, vertSrc);
+const fShader = compileShader(gl.FRAGMENT_SHADER, fragSrc);
+
+gl.attachShader(program, vShader);
+gl.attachShader(program, fShader);
+gl.linkProgram(program);
+
+gl.useProgram(program);
+
+const positionLoc = gl.getAttribLocation(program, 'a_position');
+const buffer = gl.createBuffer();
+
+gl.bindBuffer(gl.ARRAY_BUFFER, buffer);
+// full screen triangle
+const vertices = new Float32Array([
+  -1, -1,
+   3, -1,
+  -1, 3,
+]);
+gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+
+gl.enableVertexAttribArray(positionLoc);
+
+gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 0, 0);
+
+const u_c = gl.getUniformLocation(program, 'u_c');
+const u_zoom = gl.getUniformLocation(program, 'u_zoom');
+const u_center = gl.getUniformLocation(program, 'u_center');
+const u_resolution = gl.getUniformLocation(program, 'u_resolution');
+
+let zoom = 2.5;
+let center = {x:0, y:0};
+const cVal = {x:-0.4, y:0.6};
+
+document.getElementById('cval').textContent = `${cVal.x} + ${cVal.y}i`;
+
+gl.uniform2f(u_c, cVal.x, cVal.y);
+
+gl.uniform2f(u_resolution, canvas.width, canvas.height);
+
+gl.clearColor(0,0,0,1);
+
+function render(){
+  zoom *= 0.97;
+  gl.uniform1f(u_zoom, zoom);
+  gl.uniform2f(u_center, center.x, center.y);
+
+  gl.clear(gl.COLOR_BUFFER_BIT);
+  gl.drawArrays(gl.TRIANGLES, 0, 3);
+  requestAnimationFrame(render);
+}
+render();
+</script>
+</body>
+</html>

--- a/julia_visualizer.py
+++ b/julia_visualizer.py
@@ -1,12 +1,13 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Slider
+from matplotlib.animation import FuncAnimation
 
 
-def compute_julia(width, height, c, max_iter=300):
-    # Create complex plane
-    x = np.linspace(-1.5, 1.5, width)
-    y = np.linspace(-1.5, 1.5, height)
+def compute_julia(width, height, c, max_iter=300, xlim=(-1.5, 1.5), ylim=(-1.5, 1.5)):
+    """Compute the Julia set for a region of the complex plane."""
+    x = np.linspace(xlim[0], xlim[1], width)
+    y = np.linspace(ylim[0], ylim[1], height)
     X, Y = np.meshgrid(x, y)
     Z = X + 1j * Y
     C = np.full(Z.shape, c)
@@ -31,12 +32,14 @@ def compute_julia(width, height, c, max_iter=300):
 def main():
     width, height = 600, 600
     c = complex(-0.4, 0.6)
+    xlim = [-1.5, 1.5]
+    ylim = [-1.5, 1.5]
 
     fig, ax = plt.subplots()
     plt.subplots_adjust(bottom=0.25)
 
-    fractal = compute_julia(width, height, c)
-    im = ax.imshow(fractal, cmap='magma', origin='lower', extent=[-1.5, 1.5, -1.5, 1.5])
+    fractal = compute_julia(width, height, c, xlim=xlim, ylim=ylim)
+    im = ax.imshow(fractal, cmap='magma', origin='lower', extent=[xlim[0], xlim[1], ylim[0], ylim[1]])
     ax.set_xlabel('Re(z)')
     ax.set_ylabel('Im(z)')
     fig.suptitle(f'c = {c.real:.3f} + {c.imag:.3f}i')
@@ -50,13 +53,36 @@ def main():
 
     def update(val):
         c_new = complex(c_real_slider.val, c_imag_slider.val)
-        data = compute_julia(width, height, c_new)
+        data = compute_julia(width, height, c_new, xlim=tuple(xlim), ylim=tuple(ylim))
         im.set_data(data)
+        im.set_extent([xlim[0], xlim[1], ylim[0], ylim[1]])
         fig.suptitle(f'c = {c_new.real:.3f} + {c_new.imag:.3f}i')
         fig.canvas.draw_idle()
 
     c_real_slider.on_changed(update)
     c_imag_slider.on_changed(update)
+
+    def zoom(frame):
+        range_x = (xlim[1] - xlim[0]) * 0.97
+        range_y = (ylim[1] - ylim[0]) * 0.97
+        center_x = (xlim[0] + xlim[1]) / 2
+        center_y = (ylim[0] + ylim[1]) / 2
+        xlim[0] = center_x - range_x / 2
+        xlim[1] = center_x + range_x / 2
+        ylim[0] = center_y - range_y / 2
+        ylim[1] = center_y + range_y / 2
+
+        c_current = complex(c_real_slider.val, c_imag_slider.val)
+        data = compute_julia(width, height, c_current, xlim=tuple(xlim), ylim=tuple(ylim))
+        im.set_data(data)
+        im.set_extent([xlim[0], xlim[1], ylim[0], ylim[1]])
+        return [im]
+
+    # Store the animation object so it isn't garbage collected prematurely
+    anim = FuncAnimation(fig, zoom, frames=200, interval=50, blit=False)
+
+    # Keep a reference to the animation in the figure object for clarity
+    fig.anim = anim
 
     plt.show()
 


### PR DESCRIPTION
## Summary
- create `index.html` with WebGL shader implementation for real-time Julia set zooming

## Testing
- `python -m py_compile julia_visualizer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f405e5d14833099a5bbde11a5d89f